### PR TITLE
Alignment of date(s) with title.

### DIFF
--- a/src/resources/css/style.css
+++ b/src/resources/css/style.css
@@ -28,8 +28,8 @@
 	margin: 16px 0;
 }
 
-.tribe-events .tribe-events-calendar-summary__event-wrapper--multi-event {
-	margin-top: -2px;
+.tribe-common--breakpoint-medium.tribe-events .tribe-events-calendar-summary__event-wrapper--multi-event {
+	margin-top: -4px;
 }
 
 .tribe-common--breakpoint-medium.tribe-events .tribe-events-calendar-summary .tribe-events-calendar-list__event-row {
@@ -75,15 +75,16 @@
 }
 
 .tribe-events .tribe-events-calendar-summary__event-datetime-wrapper {
-	margin-bottom: 4px;
+	align-self: baseline;
 }
 
-.tribe-common--breakpoint-medium .tribe-events-calendar-summary__event-datetime-wrapper {
+.tribe-common--breakpoint-medium.tribe-common .tribe-events-calendar-summary__event-datetime-wrapper {
 	display: block;
 	flex-grow: 0;
 	flex-shrink: 0;
 	margin-bottom: 0;
 	width: 174px;
+	line-height: 1.89;
 }
 
 .tribe-common--breakpoint-medium .tribe-events-calendar-summary__event-title {

--- a/src/views/v2/summary.php
+++ b/src/views/v2/summary.php
@@ -74,6 +74,9 @@ add_filter( 'tribe_format_second_date_in_range', static function() {
 
 			<?php foreach ( $events_by_date as $group_date => $events_data ) : ?>
 				<?php
+					if ( empty( $events_data ) ) {
+						continue;
+					}
 					$event = current( $events_data );
 					$this->setup_postdata( $event );
 					$group_date = Dates::build_date_object( $group_date );

--- a/src/views/v2/summary/date-group.php
+++ b/src/views/v2/summary/date-group.php
@@ -26,7 +26,7 @@ $container_classes = [ 'tribe-common-g-row', 'tribe-events-calendar-list__event-
 	<?php $this->setup_postdata( $event ); ?>
 	<?php $this->template( 'summary/event/date-tag', [ 'event' => $event, 'group_date' => $group_date ] ); ?>
 
-	<div class="tribe-events-calendar-summary__event-wrapper <?php if ( 1 < count( $events_for_date) ) { echo esc_attr('tribe-events-calendar-summary__event-wrapper--multi-event'); } ?> tribe-common-g-col">
+	<div class="tribe-common-g-col tribe-events-calendar-summary__event-wrapper <?php if ( 1 < count( $events_for_date) ) { echo esc_attr('tribe-events-calendar-summary__event-wrapper--multi-event'); } ?>">
 		<?php foreach ( $events_for_date as $event ) : ?>
 			<?php $this->setup_postdata( $event ); ?>
 			<?php $this->template( 'summary/event', [ 'event' => $event, 'group_date' => $group_date ] ); ?>

--- a/src/views/v2/summary/date-separator.php
+++ b/src/views/v2/summary/date-separator.php
@@ -21,7 +21,7 @@
 ?>
 <div class="tribe-events-calendar-list__date-separator">
 	<time
-		class="tribe-events-calendar-list__date-separator-text tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt"
+		class="tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt tribe-events-calendar-list__date-separator-text"
 		datetime="<?php echo esc_attr( $group_date->format( 'Y-m-d' ) ); ?>"
 	>
 	</time>

--- a/src/views/v2/summary/event.php
+++ b/src/views/v2/summary/event.php
@@ -23,7 +23,7 @@ $event_classes['tribe-events-calendar-summary__event-row--featured'] = $event->f
 ?>
 <article <?php tribe_classes( $event_classes ) ?>>
 
-	<div class="tribe-events-calendar-summary__event-details tribe-common-g-col">
+	<div class="tribe-common-g-col tribe-events-calendar-summary__event-details">
 
 		<header class="tribe-events-calendar-summary__event-header">
 			<?php $this->template( 'summary/event/date', [ 'event' => $event, 'group_date' => $group_date ] ); ?>

--- a/src/views/v2/summary/event/date-tag.php
+++ b/src/views/v2/summary/event/date-tag.php
@@ -34,12 +34,12 @@ $event_week_day  = $display_date->format_i18n( 'D' );
 $event_day_num   = $display_date->format_i18n( 'j' );
 $event_date_attr = $display_date->format( Dates::DBDATEFORMAT );
 ?>
-<div class="tribe-events-calendar-list__event-date-tag tribe-common-g-col">
+<div class="tribe-common-g-col tribe-events-calendar-list__event-date-tag">
 	<time class="tribe-events-calendar-list__event-date-tag-datetime" datetime="<?php echo esc_attr( $event_date_attr ); ?>">
 		<span class="tribe-events-calendar-list__event-date-tag-weekday">
 			<?php echo esc_html( $event_week_day ); ?>
 		</span>
-		<span class="tribe-events-calendar-list__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
+		<span class="tribe-common-h5 tribe-common-h4--min-medium tribe-events-calendar-list__event-date-tag-daynum">
 			<?php echo esc_html( $event_day_num ); ?>
 		</span>
 	</time>

--- a/src/views/v2/summary/event/date.php
+++ b/src/views/v2/summary/event/date.php
@@ -24,7 +24,7 @@ $event->schedule_details;
 $formatted_start_date = $event->dates->start->format( Dates::DBDATEFORMAT );
 $formatted_group_date = $group_date->format( Dates::DBDATEFORMAT );
 ?>
-<div class="tribe-events-calendar-summary__event-datetime-wrapper tribe-common-b3">
+<div class="tribe-common-b3 tribe-events-calendar-summary__event-datetime-wrapper">
 	<time class="tribe-events-calendar-summary__event-datetime" datetime="<?php echo esc_attr( $formatted_start_date ); ?>" title="<?php echo $event->start_date . ' :: ' . $event->end_date; ?>">
 		<?php if ( ! $event->multiday ) : ?>
 			<span class="tribe-event-date-start"><?php echo esc_html( $event->summary_view->start_time ); ?></span> -

--- a/src/views/v2/summary/event/title.php
+++ b/src/views/v2/summary/event/title.php
@@ -16,7 +16,7 @@
  * @see tribe_get_event() For the format of the event object.
  */
 ?>
-<h3 class="tribe-events-calendar-summary__event-title tribe-common-h8 tribe-common-h7--min-medium">
+<h3 class="tribe-common-h8 tribe-common-h7--min-medium tribe-events-calendar-summary__event-title">
 	<?php $this->template( 'summary/event/title/featured' ); ?>
 	<?php $this->template( 'summary/event/title/virtual' ); ?>
 	<a

--- a/src/views/v2/summary/month-separator.php
+++ b/src/views/v2/summary/month-separator.php
@@ -26,7 +26,7 @@ if ( empty( $month_transition[ $group_date->format( Dates::DBDATEFORMAT ) ] ) ) 
 ?>
 <div class="tribe-events-calendar-list__month-separator">
 	<time
-		class="tribe-events-calendar-list__month-separator-text  tribe-events-calendar-list__event-date-tag tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt"
+		class="tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt tribe-events-calendar-list__event-date-tag tribe-events-calendar-list__month-separator-text"
 		datetime="<?php
 		echo esc_attr( $group_date->format( 'Y-m' ) ); ?>"
 	>

--- a/src/views/v2/summary/nav/next-disabled.php
+++ b/src/views/v2/summary/nav/next-disabled.php
@@ -21,7 +21,7 @@ $events_mobile_friendly_label = sprintf( __( 'Next %1$s', 'the-events-calendar' 
 ?>
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--next">
 	<button
-		class="tribe-events-c-nav__next tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__next"
 		aria-label="<?php echo esc_attr( $label ); ?>"
 		title="<?php echo esc_attr( $label ); ?>"
 		disabled

--- a/src/views/v2/summary/nav/next.php
+++ b/src/views/v2/summary/nav/next.php
@@ -25,7 +25,7 @@ $events_mobile_friendly_label = sprintf( __( 'Next %1$s', 'the-events-calendar' 
 	<a
 		href="<?php echo esc_url( $link ); ?>"
 		rel="next"
-		class="tribe-events-c-nav__next tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__next"
 		data-js="tribe-events-view-link"
 		aria-label="<?php echo esc_attr( $label ); ?>"
 		title="<?php echo esc_attr( $label ); ?>"

--- a/src/views/v2/summary/nav/prev-disabled.php
+++ b/src/views/v2/summary/nav/prev-disabled.php
@@ -20,7 +20,7 @@ $events_mobile_friendly_label = sprintf( __( 'Previous %1$s', 'the-events-calend
 ?>
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--prev">
 	<button
-		class="tribe-events-c-nav__prev tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__prev"
 		aria-label="<?php echo esc_attr( $label ); ?>"
 		title="<?php echo esc_attr( $label ); ?>"
 		disabled

--- a/src/views/v2/summary/nav/prev.php
+++ b/src/views/v2/summary/nav/prev.php
@@ -25,7 +25,7 @@ $events_mobile_friendly_label = sprintf( __( 'Previous %1$s', 'the-events-calend
 	<a
 		href="<?php echo esc_url( $link ); ?>"
 		rel="prev"
-		class="tribe-events-c-nav__prev tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__prev"
 		data-js="tribe-events-view-link"
 		aria-label="<?php echo esc_attr( $label ); ?>"
 		title="<?php echo esc_attr( $label ); ?>"

--- a/src/views/v2/summary/nav/today.php
+++ b/src/views/v2/summary/nav/today.php
@@ -18,7 +18,7 @@
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--today">
 	<a
 		href="<?php echo esc_url( $today_url ); ?>"
-		class="tribe-events-c-nav__today tribe-common-b2"
+		class="tribe-common-b2 tribe-events-c-nav__today"
 		data-js="tribe-events-view-link"
 		aria-label="<?php esc_attr_e( 'Click to select today\'s date', 'the-events-calendar' ); ?>"
 		title="<?php esc_attr_e( 'Click to select today\'s date', 'the-events-calendar' ); ?>"


### PR DESCRIPTION
Specifically, when a day has multiple events, we ensure that the date/title line up with the day "tag" on the left.
Single-event days still center vertically.

updated on https://happy-tiger.w6.sandbox.moderntribe.qa/events/summary/

Also: make sure our more specific classes come last - so they override the common ones.

Mobile:
<img width="405" alt="Screen Shot 2021-01-11 at 10 38 46 AM" src="https://user-images.githubusercontent.com/929375/104202666-366ce380-53f9-11eb-8063-e20a2fbc72d2.png">

Desktop:
<img width="1309" alt="Screen Shot 2021-01-11 at 10 38 27 AM" src="https://user-images.githubusercontent.com/929375/104202671-37057a00-53f9-11eb-9167-658860deb2be.png">

Alignment:
<img width="931" alt="Screen Shot 2021-01-11 at 10 41 26 AM" src="https://user-images.githubusercontent.com/929375/104202986-9b283e00-53f9-11eb-97c1-200675375840.png">

